### PR TITLE
core: operator to skip reconcile of mgr, rgw, mds and rbd-mirror daem…

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -37,6 +37,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-mgr")
@@ -114,6 +115,11 @@ func (c *Cluster) Start() error {
 	daemonIDs := c.getDaemonIDs()
 	var deploymentsToWaitFor []*v1.Deployment
 
+	mgrsToSkipReconcile, err := c.getMGRsToSkipReconcile()
+	if err != nil {
+		return errors.Wrap(err, "failed to check for mgrs to skip reconcile")
+	}
+
 	for _, daemonID := range daemonIDs {
 		if c.clusterInfo.Context.Err() != nil {
 			return c.clusterInfo.Context.Err()
@@ -150,6 +156,11 @@ func (c *Cluster) Start() error {
 				return errors.Wrapf(err, "failed to create mgr deployment %s", resourceName)
 			}
 			logger.Infof("deployment for mgr %s already exists. updating if needed", resourceName)
+
+			if mgrsToSkipReconcile.Has(daemonID) {
+				logger.Warningf("Skipping reconcile of mgr %q since labeled with %s", daemonID, cephv1.SkipReconcileLabelKey)
+				continue
+			}
 
 			if err := updateDeploymentAndWait(c.context, c.clusterInfo, d, config.MgrType, mgrConfig.DaemonID, c.spec.SkipUpgradeChecks, false); err != nil {
 				logger.Errorf("failed to update mgr deployment %q. %v", resourceName, err)
@@ -573,4 +584,21 @@ func applyMonitoringLabels(c *Cluster, serviceMonitor *monitoringv1.ServiceMonit
 			logger.Info("monitoring labels not specified")
 		}
 	}
+}
+
+func (c *Cluster) getMGRsToSkipReconcile() (sets.Set[string], error) {
+	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s,%s", k8sutil.AppAttr, AppName, cephv1.SkipReconcileLabelKey)}
+	deployments, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).List(c.clusterInfo.Context, listOpts)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query mgrs to skip reconcile")
+	}
+	result := sets.New[string]()
+	for _, deployment := range deployments.Items {
+		if mgrID, ok := deployment.Labels[config.MgrType]; ok {
+			logger.Infof("found mgr %q pod to skip reconcile", mgrID)
+			result.Insert(mgrID)
+		}
+	}
+	return result, nil
 }


### PR DESCRIPTION
…ons in debug

During certain maintenance tasks the admin will own running operations on the ceph mgr, rgw, mds and rbd-mirror daemons and the operator should not interfere with those operations.

<!-- Please take a look at our Contributing documentation before submitting a Pull Request!
https://rook.io/docs/rook/latest/Contributing/development-flow/

Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
